### PR TITLE
Prettier Errors

### DIFF
--- a/api/routes/common.js
+++ b/api/routes/common.js
@@ -12,7 +12,7 @@ const Common = class {
       token = await User.isAuth(req.headers.authorization);
     } catch (error) {
       return res.status(401).json({
-        message: error.message,
+        msg: error.message,
       });
     }
     return token;
@@ -36,7 +36,7 @@ const Common = class {
       token = await User.isAuth(req.headers.authorization);
     } catch (error) {
       return res.status(401).json({
-        message: error.message,
+        msg: error.message,
       });
     }
     try {

--- a/api/routes/company.js
+++ b/api/routes/company.js
@@ -12,7 +12,7 @@ router.get('/get', async (req, res) => {
     token = await User.isAuth(req.headers.authorization);
   } catch (error) {
     return res.status(401).json({
-      message: error.message,
+      msg: error.message,
     });
   }
   try {
@@ -31,7 +31,7 @@ router.get('/get/:user', async (req, res) => {
     await User.isAuth(req.headers.authorization);
   } catch (error) {
     return res.status(401).json({
-      message: error.message,
+      msg: error.message,
     });
   }
   try {

--- a/api/server.js
+++ b/api/server.js
@@ -37,7 +37,7 @@ app.use('/api/jobs', job);
 // Handling Errors
 app.use((err, _req, res) => {
   res.status(err.statusCode || 500).json({
-    message: err.message || 'Internal Server Error',
+    msg: err.message || 'Internal Server Error',
   });
 });
 

--- a/ui/src/components/Filter/Filter.jsx
+++ b/ui/src/components/Filter/Filter.jsx
@@ -41,8 +41,10 @@ function Filter(props) {
     if (ws.data) {
       const { message } = ws.data;
       if (Array.isArray(message)) {
-        setAllJobs(message);
-        setFilteredJobs(message);
+        if (message.length !== allJobs.length) {
+          setAllJobs(message);
+          setFilteredJobs(message);
+        }
       }
     }
   }, [currentUser, ws.data]);

--- a/ui/src/helpers/handle-response.js
+++ b/ui/src/helpers/handle-response.js
@@ -2,16 +2,23 @@
 import { authenticationService } from '../services/authentication.service';
 
 export function handleResponse(response) {
-  return response.text().then((text) => {
-    const data = text && JSON.parse(text);
-    if (!response.ok) {
-      if ([401, 403].indexOf(response.status) !== -1) {
-        // auto logout if 401 Unauthorized or 403 Forbidden response returned from api
-        authenticationService.logout();
-        // location.reload()
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    // if a json response
+    return response.json().then((data) => {
+      if (!response.ok) {
+        if ([401, 403].indexOf(response.status) !== -1) {
+          // auto logout if 401 Unauthorized or 403 Forbidden response returned from api
+          authenticationService.logout();
+          // location.reload()
+        }
+        return Promise.reject(data.msg);
       }
-      return Promise.reject(data.msg);
-    }
-    return data;
+      return data;
+    });
+  }
+  // otherwise must be an error
+  return response.text().then((text) => {
+    Promise.reject(text);
   });
 }


### PR DESCRIPTION
When plain text comes back, treat it by default as an error, all errors and messages should be json content, with all errors being in `msg`
Closes #548 